### PR TITLE
Wait for dates to load before running

### DIFF
--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -31,7 +31,7 @@ const runWhenReady = (elementFinder, callback) => {
         );
       } else {
         setTimeout(
-          tryNow.apply(null, attempt + 1),
+          tryNow.apply(null, [attempt + 1]),
           250 * Math.pow(1.1, attempt)
         );
       }

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -40,7 +40,7 @@ function runWhenReady(elementFinder, callback) {
 
 function findReviews() {
   // reviews are within `p` elements, but not all `p` are reviews.
-  [...document.querySelectorAll("p")].filter((e) =>
+  return [...document.querySelectorAll("p")].filter((e) =>
     new RegExp("(N° d'article|Art.-Nr.|No.-art.) [0-9]+", "g").test(e.innerText)
   );
 }

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -17,9 +17,9 @@
 // Gives up after a minute.
 // Inspired from
 // https://github.com/Tampermonkey/tampermonkey/issues/1279#issuecomment-875386821
-function runWhenReady(elementFinder, callback) {
+const runWhenReady = (elementFinder, callback) => {
   let numAttempts = 0;
-  const tryNow = function () {
+  const tryNow = () => {
     const el = elementFinder();
     const elFound = el.length > 0;
 
@@ -38,23 +38,23 @@ function runWhenReady(elementFinder, callback) {
   };
 
   tryNow();
-}
+};
 
-function findDates() {
+const findDates = () => {
   // Array.prototype.join only inserts between elements but doesn't prepend.
   const dateElClasses = `.${["jss89", "jss119", "jss99"].join(".")}`;
 
   return [...document.querySelectorAll(dateElClasses)];
-}
+};
 
-function findReviews() {
+const findReviews = () => {
   // reviews are within `p` elements, but not all `p` are reviews.
   return [...document.querySelectorAll("p")].filter((e) =>
     new RegExp("(N° d'article|Art.-Nr.|No.-art.) [0-9]+", "g").test(e.innerText)
   );
-}
+};
 
-function addLinks() {
+const addLinks = () => {
   findReviews().map((e) => {
     // Match current page language to link to the item in the corresponding
     // language.
@@ -66,7 +66,7 @@ function addLinks() {
     e.innerText = e.innerText.replace(artNum, "");
     e.insertAdjacentElement("beforeEnd", anchor);
   });
-}
+};
 
 // Ricardo does very "interesting" things to the page. One such interesting
 // thing is to load review dates much later, which deletes and recreates

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Link ratings to ads
 // @namespace    http://tampermonkey.net/
-// @version      0.1
+// @version      0.2
 // @description  Turn article numbers into links to the corresponding listing on the Ricardo.ch user's evaluations page.
 // @author       Coaxial
 // @match        https://www.ricardo.ch/*/shop/*/ratings*

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -12,23 +12,25 @@
 
 "use strict";
 
-// Some content is loaded later, this checks if reviews have been loaded yet
-// before running transformations on them.
+// Checks if the page is ready done loading the elements to modify before
+// operating on them.
 // Gives up after a minute.
 // Inspired from
 // https://github.com/Tampermonkey/tampermonkey/issues/1279#issuecomment-875386821
 function runWhenReady(elementFinder, callback) {
   const numAttempts = 0;
   const tryNow = function () {
-    const reviews = elementFinder();
-    const reviewsFound = reviews.length > 0;
+    const el = elementFinder();
+    const elFound = el.length > 0;
 
-    if (reviewsFound) {
-      callback(reviews);
+    if (elFound) {
+      callback();
     } else {
       numAttempts++;
       if (numAttempts >= 34) {
-        console.warn("Giving up after 34 attempts. Could not find any reviews");
+        console.warn(
+          `Couldn't find any matching elements after ${numAttemps}, giving up.`
+        );
       } else {
         setTimeout(tryNow, 250 * Math.pow(1.1, numAttempts));
       }
@@ -38,6 +40,12 @@ function runWhenReady(elementFinder, callback) {
   tryNow();
 }
 
+function findDates() {
+  const dateElClasses = ["jss89", "jss119", "jss99"].join(".");
+
+  return [...document.querySelectorAll(dateElClasses)];
+}
+
 function findReviews() {
   // reviews are within `p` elements, but not all `p` are reviews.
   return [...document.querySelectorAll("p")].filter((e) =>
@@ -45,8 +53,8 @@ function findReviews() {
   );
 }
 
-function addLinks(reviews) {
-  reviews.map((e) => {
+function addLinks() {
+  findReviews().map((e) => {
     // Match current page language to link to the item in the corresponding
     // language.
     const lang = location.toString().match(/(fr|de|it|en)/)[0];
@@ -59,4 +67,9 @@ function addLinks(reviews) {
   });
 }
 
-runWhenReady(findReviews, addLinks);
+// Ricardo does very "interesting" things to the page. One such interesting
+// thing is to load review dates much later, which deletes and recreates
+// the item number elements once the date has been loaded.
+// Therefore, we must wait for the dates to load, and for the item number
+// elements to be removed and recreated before modifying them.
+runWhenReady(findDates, addLinks);

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -29,7 +29,7 @@ function runWhenReady(elementFinder, callback) {
       numAttempts++;
       if (numAttempts >= 34) {
         console.warn(
-          `Couldn't find any matching elements after ${numAttemps}, giving up.`
+          `Couldn't find any matching elements after ${numAttempts}, giving up.`
         );
       } else {
         setTimeout(tryNow, 250 * Math.pow(1.1, numAttempts));

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -27,7 +27,7 @@ const runWhenReady = (elementFinder, callback) => {
     } else {
       if (attempt == 33) {
         console.warn(
-          `Couldn't find any matching elements after ${attempt} attempts, giving up.`
+          `No matching elements after ${attempt} attempts, giving up.`
         );
       } else {
         setTimeout(() => tryNow(attempt + 1), 250 * Math.pow(1.1, attempt));
@@ -54,7 +54,8 @@ const findReviews = () => {
 
 const ricardoCantCss = () => {
   // Remove useless negative margins so that the item number isn't covered by
-  // another element and is clickable. CSS is hard I guess.
+  // another element and is clickable.
+  // CSS is hard I guess.
   findDates().map((el) => {
     el.parentElement.style["padding-top"] = 0;
     el.parentElement.style["padding-left"] = 0;
@@ -74,13 +75,14 @@ const addLinks = () => {
     anchor.innerText = artNum;
     e.innerText = e.innerText.replace(artNum, "");
     e.insertAdjacentElement("beforeEnd", anchor);
+    // Make item numbers clickable.
     ricardoCantCss();
   });
 };
 
-// Ricardo does very "interesting" things to the page. One such interesting
-// thing is to load review dates much later, which deletes and recreates
-// the item number elements once the date has been loaded.
-// Therefore, we must wait for the dates to load, and for the item number
-// elements to be removed and recreated before modifying them.
+// Ricardo does things in a very "interesting" way. One such interesting thing
+// is to load review dates much later, then delete and immediately recreate the
+// item number elements once the date has been loaded. Therefore, we must wait
+// for the dates to load and for the item number elements to be removed and
+// recreated before modifying them.
 runWhenReady(findDates, addLinks);

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -7,28 +7,25 @@
 // @match        https://www.ricardo.ch/*/shop/*/ratings*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=ricardo.ch
 // @grant        none
-// @homepage	 https://github.com/coaxial/tampermonkey-scripts
+// @homepage     https://github.com/coaxial/tampermonkey-scripts
 // ==/UserScript==
 
 (function () {
-	"use strict";
+  "use strict";
 
-	[...document.querySelectorAll("p")]
-		.filter((e) =>
-			new RegExp(
-				"(N° d'article|Art.-Nr.|No.-art.) [0-9]+",
-				"g"
-			).test(e.innerText)
-		)
-		.map((e) => {
-			const lang = location
-				.toString()
-				.match(/(fr|de|it|en)/)[0];
-			const artNum = e.innerText.match(/[0-9]+/g);
-			const anchor = document.createElement("a");
-			anchor.href = `/${lang}/a/${artNum}/`;
-			anchor.innerText = artNum;
-			e.innerText = e.innerText.replace(artNum, "");
-			e.insertAdjacentElement("beforeEnd", anchor);
-		});
+  [...document.querySelectorAll("p")]
+    .filter((e) =>
+      new RegExp("(N° d'article|Art.-Nr.|No.-art.) [0-9]+", "g").test(
+        e.innerText
+      )
+    )
+    .map((e) => {
+      const lang = location.toString().match(/(fr|de|it|en)/)[0];
+      const artNum = e.innerText.match(/[0-9]+/g);
+      const anchor = document.createElement("a");
+      anchor.href = `/${lang}/a/${artNum}/`;
+      anchor.innerText = artNum;
+      e.innerText = e.innerText.replace(artNum, "");
+      e.insertAdjacentElement("beforeEnd", anchor);
+    });
 })();

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -55,7 +55,7 @@ const findReviews = () => {
 const ricardoCantCss = () => {
   // Remove useless negative margins so that the item number isn't covered by
   // another element and is clickable. CSS is hard I guess.
-  findDates.map((el) => {
+  findDates().map((el) => {
     el.parentElement.style = {
       "padding-top": 0,
       "padding-left": 0,

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -18,21 +18,22 @@
 // Inspired from
 // https://github.com/Tampermonkey/tampermonkey/issues/1279#issuecomment-875386821
 const runWhenReady = (elementFinder, callback) => {
-  let numAttempts = 0;
-  const tryNow = () => {
+  const tryNow = (attempt = 0) => {
     const el = elementFinder();
     const elFound = el.length > 0;
 
     if (elFound) {
       callback();
     } else {
-      numAttempts++;
-      if (numAttempts >= 34) {
+      if (attempt == 33) {
         console.warn(
-          `Couldn't find any matching elements after ${numAttempts} attempts, giving up.`
+          `Couldn't find any matching elements after ${attempt} attempts, giving up.`
         );
       } else {
-        setTimeout(tryNow, 250 * Math.pow(1.1, numAttempts));
+        setTimeout(
+          tryNow.apply(null, attempt + 1),
+          250 * Math.pow(1.1, attempt)
+        );
       }
     }
   };

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -56,14 +56,10 @@ const ricardoCantCss = () => {
   // Remove useless negative margins so that the item number isn't covered by
   // another element and is clickable. CSS is hard I guess.
   findDates().map((el) => {
-    el.parentElement.style = {
-      "padding-top": 0,
-      "padding-left": 0,
-    };
-    el.parentElement.parentElement.style = {
-      "margin-top": 0,
-      "margin-left": 0,
-    };
+    el.parentElement.style["padding-top"] = 0;
+    el.parentElement.style["padding-left"] = 0;
+    el.parentElement.parentElement.style["margin-top"] = 0;
+    el.parentElement.parentElement.style["margin-left"] = 0;
   });
 };
 

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -52,6 +52,21 @@ const findReviews = () => {
   );
 };
 
+const ricardoCantCss = () => {
+  // Remove useless negative margins so that the item number isn't covered by
+  // another element and is clickable. CSS is hard I guess.
+  findDates.map((el) => {
+    el.parentElement.style = {
+      "padding-top": 0,
+      "padding-left": 0,
+    };
+    el.parentElement.parentElement.style = {
+      "margin-top": 0,
+      "margin-left": 0,
+    };
+  });
+};
+
 const addLinks = () => {
   findReviews().map((e) => {
     // Match current page language to link to the item in the corresponding
@@ -63,6 +78,7 @@ const addLinks = () => {
     anchor.innerText = artNum;
     e.innerText = e.innerText.replace(artNum, "");
     e.insertAdjacentElement("beforeEnd", anchor);
+    ricardoCantCss();
   });
 };
 

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -10,22 +10,55 @@
 // @homepage     https://github.com/coaxial/tampermonkey-scripts
 // ==/UserScript==
 
-(function () {
-  "use strict";
+"use strict";
 
-  [...document.querySelectorAll("p")]
-    .filter((e) =>
-      new RegExp("(N° d'article|Art.-Nr.|No.-art.) [0-9]+", "g").test(
-        e.innerText
-      )
-    )
-    .map((e) => {
-      const lang = location.toString().match(/(fr|de|it|en)/)[0];
-      const artNum = e.innerText.match(/[0-9]+/g);
-      const anchor = document.createElement("a");
-      anchor.href = `/${lang}/a/${artNum}/`;
-      anchor.innerText = artNum;
-      e.innerText = e.innerText.replace(artNum, "");
-      e.insertAdjacentElement("beforeEnd", anchor);
-    });
-})();
+// Some content is loaded later, this checks if reviews have been loaded yet
+// before running transformations on them.
+// Gives up after a minute.
+// Inspired from
+// https://github.com/Tampermonkey/tampermonkey/issues/1279#issuecomment-875386821
+function runWhenReady(elementFinder, callback) {
+  const numAttempts = 0;
+  const tryNow = function () {
+    const reviews = elementFinder();
+    const reviewsFound = reviews.length > 0;
+
+    if (reviewsFound) {
+      callback(reviews);
+    } else {
+      numAttempts++;
+      if (numAttempts >= 34) {
+        console.warn(
+          "Giving up after 34 attempts. Could not find: " + readySelector
+        );
+      } else {
+        setTimeout(tryNow, 250 * Math.pow(1.1, numAttempts));
+      }
+    }
+  };
+
+  tryNow();
+}
+
+function findReviews() {
+  // reviews are within `p` elements, but not all `p` are reviews.
+  [...document.querySelectorAll("p")].filter((e) =>
+    new RegExp("(N° d'article|Art.-Nr.|No.-art.) [0-9]+", "g").test(e.innerText)
+  );
+}
+
+function addLinks(reviews) {
+  reviews.map((e) => {
+    // Match current page language to link to the item in the corresponding
+    // language.
+    const lang = location.toString().match(/(fr|de|it|en)/)[0];
+    const artNum = e.innerText.match(/[0-9]+/g);
+    const anchor = document.createElement("a");
+    anchor.href = `/${lang}/a/${artNum}/`;
+    anchor.innerText = artNum;
+    e.innerText = e.innerText.replace(artNum, "");
+    e.insertAdjacentElement("beforeEnd", anchor);
+  });
+}
+
+runWhenReady(findReviews, addLinks);

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -28,9 +28,7 @@ function runWhenReady(elementFinder, callback) {
     } else {
       numAttempts++;
       if (numAttempts >= 34) {
-        console.warn(
-          "Giving up after 34 attempts. Could not find: " + readySelector
-        );
+        console.warn("Giving up after 34 attempts. Could not find any reviews");
       } else {
         setTimeout(tryNow, 250 * Math.pow(1.1, numAttempts));
       }

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -30,10 +30,7 @@ const runWhenReady = (elementFinder, callback) => {
           `Couldn't find any matching elements after ${attempt} attempts, giving up.`
         );
       } else {
-        setTimeout(
-          tryNow.apply(null, [attempt + 1]),
-          250 * Math.pow(1.1, attempt)
-        );
+        setTimeout(() => tryNow(attempt + 1), 250 * Math.pow(1.1, attempt));
       }
     }
   };

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -29,7 +29,7 @@ function runWhenReady(elementFinder, callback) {
       numAttempts++;
       if (numAttempts >= 34) {
         console.warn(
-          `Couldn't find any matching elements after ${numAttempts}, giving up.`
+          `Couldn't find any matching elements after ${numAttempts} attempts, giving up.`
         );
       } else {
         setTimeout(tryNow, 250 * Math.pow(1.1, numAttempts));
@@ -41,7 +41,8 @@ function runWhenReady(elementFinder, callback) {
 }
 
 function findDates() {
-  const dateElClasses = ["jss89", "jss119", "jss99"].join(".");
+  // Array.prototype.join only inserts between elements but doesn't prepend.
+  const dateElClasses = `.${["jss89", "jss119", "jss99"].join(".")}`;
 
   return [...document.querySelectorAll(dateElClasses)];
 }

--- a/ricardoch/adlinks.js
+++ b/ricardoch/adlinks.js
@@ -18,7 +18,7 @@
 // Inspired from
 // https://github.com/Tampermonkey/tampermonkey/issues/1279#issuecomment-875386821
 function runWhenReady(elementFinder, callback) {
-  const numAttempts = 0;
+  let numAttempts = 0;
   const tryNow = function () {
     const el = elementFinder();
     const elFound = el.length > 0;


### PR DESCRIPTION
The reviews page loads the date much later than the rest of the content. Once the dates are loaded, the review elements are deleted from the DOM and recreated. This patch waits for the date to have loaded and the elements to have been recreated before modifying them. It then fixes Ricardo's CSS so that the item number isn't burried under the date element and can be clicked or selected.

Close #2 